### PR TITLE
Make SeekableSMBByteChannel.close() idempotent

### DIFF
--- a/src/main/java/ch/pontius/nio/smb/SeekableSMBByteChannel.java
+++ b/src/main/java/ch/pontius/nio/smb/SeekableSMBByteChannel.java
@@ -155,7 +155,7 @@ public final class SeekableSMBByteChannel implements SeekableByteChannel {
      */
     @Override
     public synchronized void close() throws IOException {
-        if (!this.open) throw new ClosedChannelException();
+        if (!this.open) return;
         this.open = false;
         this.random.close();
     }


### PR DESCRIPTION
The docs on Channel.close() are pretty clear that this is allowed to be invoked multiple times.