### PR TITLE
Fixed NullPointerException in SMBFileAttributeView::setTimes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>eu.agno3.jcifs</groupId>
             <artifactId>jcifs-ng</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/ch/pontius/nio/smb/SMBFileAttributeView.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBFileAttributeView.java
@@ -50,16 +50,11 @@ public final class SMBFileAttributeView implements BasicFileAttributeView {
             return;
         }
 
-        final SmbFile file = this.path.getSmbFile();
+        long lastModified = lastModifiedTime != null ? lastModifiedTime.to(TimeUnit.MILLISECONDS) : 0L;
+        long lastAccess = lastAccessTime != null ? lastAccessTime.to(TimeUnit.MILLISECONDS) : 0L;
+        long create = createTime != null ? createTime.to(TimeUnit.MILLISECONDS) : 0L;
 
-        if (lastModifiedTime != null) {
-            file.setLastModified(lastModifiedTime.to(TimeUnit.MILLISECONDS));
-        }
-        if (lastAccessTime != null) {
-            file.setLastAccess(lastAccessTime.to(TimeUnit.MILLISECONDS));
-        }
-        if (createTime != null) {
-            file.setCreateTime(createTime.to(TimeUnit.MILLISECONDS));
-        }
+        final SmbFile file = this.path.getSmbFile();
+        file.setFileTimes(create, lastModified, lastAccess);
     }
 }

--- a/src/main/java/ch/pontius/nio/smb/SMBFileAttributeView.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBFileAttributeView.java
@@ -46,8 +46,20 @@ public final class SMBFileAttributeView implements BasicFileAttributeView {
 
     @Override
     public void setTimes(FileTime lastModifiedTime, FileTime lastAccessTime, FileTime createTime) throws IOException {
+        if (lastModifiedTime == null && lastAccessTime == null && createTime == null) {
+            return;
+        }
+
         final SmbFile file = this.path.getSmbFile();
-        file.setLastModified(lastModifiedTime.to(TimeUnit.MILLISECONDS));
-        file.setCreateTime(createTime.to(TimeUnit.MILLISECONDS));
+
+        if (lastModifiedTime != null) {
+            file.setLastModified(lastModifiedTime.to(TimeUnit.MILLISECONDS));
+        }
+        if (lastAccessTime != null) {
+            file.setLastAccess(lastAccessTime.to(TimeUnit.MILLISECONDS));
+        }
+        if (createTime != null) {
+            file.setCreateTime(createTime.to(TimeUnit.MILLISECONDS));
+        }
     }
 }


### PR DESCRIPTION
`BasicFileAttributeView::setTimes` is designed to accept null values. See [docs](https://docs.oracle.com/javase/8/docs/api/java/nio/file/attribute/BasicFileAttributeView.html#setTimes-java.nio.file.attribute.FileTime-java.nio.file.attribute.FileTime-java.nio.file.attribute.FileTime-).