### PR TITLE
Fix #12

### DIFF
--- a/src/main/java/ch/pontius/nio/smb/SMBFileSystem.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBFileSystem.java
@@ -14,6 +14,7 @@ import java.nio.file.spi.FileSystemProvider;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class represents a single SMB server (filesystem). The authority part of the SMB URI creates a unique {@link SMBFileSystem}, that is,
@@ -170,12 +171,16 @@ public final class SMBFileSystem extends FileSystem {
     @Override
     public Path getPath(String first, String... more) {
         if (!this.isOpen()) throw new ClosedFileSystemException();
-        final String[] components = new String[more.length + 1];
-        components[0] = first;
-        if (more.length > 0) {
-            System.arraycopy(more, 0, components, 1, more.length);
-        }
-        final String path = SMBPathUtil.mergePath(components, 0, components.length, first.startsWith("/"), more[more.length-1].endsWith("/"));
+        String[] components = Stream.concat(Arrays.stream(new String[] { first }), Arrays.stream(more))
+                .toArray(String[]::new);
+        boolean folder = components[components.length - 1].endsWith("/");
+        final String path = SMBPathUtil.mergePath(
+                components,
+                0,
+                components.length,
+                first.startsWith("/"),
+                folder
+        );
         return new SMBPath(this, path);
     }
 

--- a/src/main/java/ch/pontius/nio/smb/SMBPathUtil.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBPathUtil.java
@@ -64,11 +64,16 @@ public final class SMBPathUtil {
      * @return Resulting path string
      */
     public static String mergePath(String[] components, int start, int end, boolean absolute, boolean folder) {
+        if (components.length == 0) return "";
+
         StringBuilder builder = new StringBuilder();
         if (absolute) builder.append(SMBFileSystem.PATH_SEPARATOR);
         for (int i = start; i<end; i++) {
-            builder.append(components[i]);
-            builder.append(SMBFileSystem.PATH_SEPARATOR);
+            String component = components[i];
+            builder.append(component);
+            if (!component.endsWith("/")) {
+                builder.append(SMBFileSystem.PATH_SEPARATOR);
+            }
         }
         if (!folder) {
             return builder.substring(0, Math.max(0,builder.length()-1));


### PR DESCRIPTION
The `ArrayIndexOutOfBoundsException` occures because it is assumed that the `more` array always has entries. I fixed this by using Java 8's `Stream` class to concatenate both parameters into one array and work with that.