### PR TITLE
Append the path instead of a path separator

### DIFF
--- a/src/main/java/ch/pontius/nio/smb/SMBPath.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBPath.java
@@ -491,7 +491,7 @@ public final class SMBPath implements Path {
     SmbFile getSmbFile() throws IOException {
         if (!this.fileSystem.isOpen()) throw new ClosedFileSystemException();
         final String path = SMBPathUtil.mergePath(this.components, 0, this.components.length, this.absolute, this.folder);
-        return new SmbFile(this.fileSystem.getFQN() + SMBFileSystem.PATH_SEPARATOR, SingletonContext.getInstance());
+        return new SmbFile(this.fileSystem.getFQN() + path, SingletonContext.getInstance());
     }
 
     /**


### PR DESCRIPTION
The actual path to list was never appended, so I always got a list of shares I could access. Appending the path - which is actually already being calculated, but not appended??? - fixes this issue.