### PR TITLE
Fixed SMBPath.compareTo and SMBPath.equals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-}
-
 plugins {
     id 'idea'
     id 'java'
@@ -84,6 +78,10 @@ signing {
 }
 
 dependencies {
-    compile group: 'eu.agno3.jcifs', name: 'jcifs-ng', version: '2.1.5'
-    compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.0'
+    implementation group: 'eu.agno3.jcifs', name: 'jcifs-ng', version: '2.1.5'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.1'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/main/java/ch/pontius/nio/smb/SMBPath.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBPath.java
@@ -7,9 +7,17 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.*;
-import java.util.*;
-
+import java.nio.file.ClosedFileSystemException;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * A {@link Path} implementation that can be used with SMBNio
@@ -465,12 +473,12 @@ public final class SMBPath implements Path {
     @Override
     public int compareTo(Path other) {
         /* Check if other path is on the same filesystem. */
-        if (!(other instanceof SMBPath))  throw new IllegalArgumentException("You can only resolve an SMB path against another SMB path.");
-        if (((SMBPath)other).fileSystem != this.fileSystem) throw new IllegalArgumentException("You can only resolve an SMB path against another SMB path on the same file system.");
+        if (!(other instanceof SMBPath))  throw new IllegalArgumentException("You can only compare an SMB path against another SMB path.");
+        if (((SMBPath)other).fileSystem != this.fileSystem) throw new IllegalArgumentException("You can only compare an SMB path against another SMB path on the same file system.");
 
         /* */
         String thisPath = SMBPathUtil.mergePath(this.components, 0, this.components.length, this.absolute, this.folder);
-        String thatPath = SMBPathUtil.mergePath(((SMBPath)other).components, 0, this.components.length, ((SMBPath)other).absolute, ((SMBPath)other).folder);
+        String thatPath = SMBPathUtil.mergePath(((SMBPath)other).components, 0, ((SMBPath)other).components.length, ((SMBPath)other).absolute, ((SMBPath)other).folder);
         return thisPath.compareTo(thatPath);
     }
 
@@ -504,7 +512,9 @@ public final class SMBPath implements Path {
     public boolean equals(Object other) {
         if (!(other instanceof SMBPath)) return false;
         if (((SMBPath)other).fileSystem != this.fileSystem) return false;
-        return Arrays.equals(this.components, ((SMBPath) other).components);
+        return Arrays.equals(this.components, ((SMBPath) other).components)
+                && this.absolute == ((SMBPath) other).absolute
+                && this.folder == ((SMBPath) other).folder;
     }
 
     /**


### PR DESCRIPTION
The path `smb://host/share/path/other` and `smb://host/share/path/other/` were considered as equal before. But this is not correct. The first one points to a file and the second one points to a directory. And since jcifs take care about trailing and leading slashes we have to check `SMBPath.absolute` and `SMBPath.folder` too, like it is already done in `SMBPath.compareTo`.

Other fixes:
* Moved junit to test dependencies
* Changed deprecated stuff in gradle build script
* Fixed typo in UnitTest and moved the test to its correct location