### PR TITLE
update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,6 @@ signing {
 }
 
 dependencies {
-    compile group: 'eu.agno3.jcifs', name: 'jcifs-ng', version: '2.1.5'
-    compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.0'
+    implementation group: 'eu.agno3.jcifs', name: 'jcifs-ng', version: '2.1.6'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.2'
 }


### PR DESCRIPTION
update dependencies
the jcifs version used transitively uses a dependency with a known vulnerability. This vulnerability is solved in a later version that is used in the recent jcifs version