### PR TITLE
Implemented `getFileStore` in `SMBFileSystemProvider`

### DIFF
--- a/src/main/java/ch/pontius/nio/smb/SMBFileSystemProvider.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBFileSystemProvider.java
@@ -461,8 +461,10 @@ public final class SMBFileSystemProvider extends FileSystemProvider {
     }
 
     @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException("Access to FileStore is currently not supported by SMBFileSystemProvider.");
+    public FileStore getFileStore(Path path) throws IOException {
+        SMBPath smbPath = SMBPath.fromPath(path);
+        String share = smbPath.getSmbFile().getShare();
+        return new SMBFileStore((SMBFileSystem) smbPath.getFileSystem(), share);
     }
 
     /**


### PR DESCRIPTION
This pull request implements `getFileStore` in `SMBFileSystemProvider`. It is required to call `Files.getFileStore(Path)` to obtain storage statistics like total or usable space.

```java
Files.getFileStore(smbPath).getTotalSpace()
```