### PR TITLE
Fix regression in SMBFileSystemProvider.constructAuthority()

### DIFF
--- a/src/main/java/ch/pontius/nio/smb/SMBFileSystemProvider.java
+++ b/src/main/java/ch/pontius/nio/smb/SMBFileSystemProvider.java
@@ -526,7 +526,6 @@ public final class SMBFileSystemProvider extends FileSystemProvider {
             if (uri.getAuthority() != null) {
                 if (builder.length() > 0) {
                     builder.append(SMBFileSystem.CREDENTIALS_SEPARATOR).append(uri.getAuthority());
-                    builder.append(builder.toString());
                 } else {
                     builder.append(uri.getAuthority());
                 }


### PR DESCRIPTION
Since 25f4eafa4c63a8dad65f99ede248641353d21c6f the authority construction is erroneous since it duplicates the intended string.
@ppanopticon you created the mentioned commit. Could you please verify that this fix is correct?