### PR TITLE
Update jcifs-ng to 2.1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ signing {
 }
 
 dependencies {
-    implementation group: 'eu.agno3.jcifs', name: 'jcifs-ng', version: '2.1.8'
+    implementation group: 'eu.agno3.jcifs', name: 'jcifs-ng', version: '2.1.10'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.1'
 }
 


### PR DESCRIPTION
jcifs-ng 2.1.8 uses an old verion of bcprov with new security issues.
In version 2.1.10 this dependency is renewed to a new verion of bcprov without those issues.